### PR TITLE
switch to annotating adhoc polymorphism

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -486,7 +486,7 @@ unification can force us to distinguish between different types. Based on these,
 example of \texttt{map} for vectors is as follows:
 
 \begin{codequote}
-vmap : [A B] (A -> B -> prop) -> vector N A -> vector N B -> prop.
+vmap : [N] (A -> B -> prop) -> vector N A -> vector N B -> prop.
 vmap P vnil vnil.
 vmap P (vcons X XS) (vcons Y YS) :- P X Y, vmap P XS YS.
 \end{codequote}
@@ -553,9 +553,9 @@ scons : A -> subst A T -> subst A (A * T).
 The predicates are now defined as follows. First, their types are:
 
 \begin{codequote}
-intromany : [A B] dbind A T B -> (subst A T -> prop) -> prop.
-applymany : [A B] dbind A T B -> subst A T -> B -> prop.
-openmany : [A B] dbind A T B -> (subst A T -> B -> prop) -> prop.
+intromany : [T] dbind A T B -> (subst A T -> prop) -> prop.
+applymany : [T] dbind A T B -> subst A T -> B -> prop.
+openmany : [T] dbind A T B -> (subst A T -> B -> prop) -> prop.
 \end{codequote}
 
 Note that we are reusing the same predicate names as before. Makam allows overloading for all
@@ -582,11 +582,11 @@ Also, we define predicates analogous to \texttt{map} and \texttt{assumemany} for
 type:
 
 \begin{codequote}
-assumemany : (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
+assumemany : [T T'] (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
 assumemany P snil snil Q :- Q.
 assumemany P (scons X XS) (scons Y YS) Q :- (P X Y -> assumemany P XS YS Q).
 
-map : [A B] (A -> B -> prop) -> subst A T -> subst B T' -> prop.
+map : [T T'] (A -> B -> prop) -> subst A T -> subst B T' -> prop.
 map P snil snil.
 map P (scons X XS) (scons Y YS) :- P X Y, map P XS YS.
 \end{codequote}
@@ -703,7 +703,7 @@ variables that remain after the pattern, yield a list of types for all the varia
 available, plus the type of the pattern.
 
 \begin{codequote}
-typeof : patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
+typeof : [T T' Ttyp T'Typ] patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
 
 typeof patt_var S' (scons T S') T.
 typeof patt_wild S S T.
@@ -711,7 +711,8 @@ typeof patt_zero S S nat.
 typeof (patt_succ P) S' S nat :-
   typeof P S' S nat.
 
-typeof_pattlist : pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
+typeof_pattlist :
+  [T T' Ttyp T'typ] pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
 
 typeof (patt_tuple PS) S' S (product TS) :-
   typeof_pattlist PS S' S TS.
@@ -737,13 +738,13 @@ introduced at each conversion rule as needed, and will get instantiated to the r
 unification with the scrutinee succeeds.
 
 \begin{codequote}
-patt_to_term : patt T T' -> term -> subst term T' -> subst term T -> prop.
+patt_to_term : [T T'] patt T T' -> term -> subst term T' -> subst term T -> prop.
 patt_to_term patt_var X Subst (scons X Subst).
 patt_to_term patt_wild _ Subst Subst.
 patt_to_term patt_zero zero Subst Subst.
 patt_to_term (patt_succ PN) (succ EN) Subst' Subst :- patt_to_term PN EN Subst' Subst.
 
-pattlist_to_termlist : pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
+pattlist_to_termlist : [T T'] pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
 
 patt_to_term (patt_tuple PS) (tuple ES) Subst' Subst :-
   pattlist_to_termlist PS ES Subst' Subst.
@@ -764,7 +765,7 @@ Two new things here: if-then-else has the semantics described in the LogicT mona
 is a predicate that forces its arguments to be unified, defined simply as:
 
 \begin{codequote}
-eq : [A] A -> A -> prop.
+eq : A -> A -> prop.
 eq X X.
 \end{codequote}
 


### PR DESCRIPTION
I've switched Makam (astampoulis/makam#5) that it requires annotation for type variables that are allowed to be specialized dynamically instead of the other way around -- so now, one needs to annotate ad-hoc polymorphic variables instead of parametric polymorphic variables.

The text was already written assuming that, so this only changes the code. I think this kind of annotation makes more sense, as we're more accustomed to thinking of type variables being parametric 'by default'.

@achlipala (I'll merge this soon, just tagging you FYI).
